### PR TITLE
Remove env file support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,0 @@
-# Sample environment file for bootstrap-docker.sh
-# Copy to .env and adjust values as needed
-PORTAINER_VERSION=2.19
-PORTAINER_ADMIN_PWD=changeme123
-PORTAINER_DATA_VOL=portainer_data
-PORTAINER_URL=https://127.0.0.1:9443
-COMPOSE_REPO_URL=https://github.com/scheric1/docker-startup
-COMPOSE_CLONE_DIR=/opt/docker-stacks

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ COMPOSE_CLONE_DIR="/opt/docker-stacks"
 
 Change these before running the script if you want to use a different repository or directory.
 
-### Using a `.env` file
-Copy `.env.sample` to `.env` and modify the values to adjust Portainer or repository settings without editing the script. Any variables defined in `.env` will override the defaults used by `bootstrap-docker.sh`.
 
 ### Organizing compose stacks
 Place each compose file inside its own subdirectory under `docker/` to create a

--- a/bootstrap-docker.sh
+++ b/bootstrap-docker.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Baseline packages
 EXTRA_PKGS=(vim jq)
 
-# Git repo containing docker compose stacks (override in .env if desired)
+# Git repo containing docker compose stacks
 COMPOSE_REPO_URL=${COMPOSE_REPO_URL:-"https://github.com/scheric1/docker-startup"}
 COMPOSE_CLONE_DIR=${COMPOSE_CLONE_DIR:-"/opt/docker-stacks"}
 
@@ -25,14 +25,6 @@ info()  { printf '\e[32m[INFO]\e[0m  %s\n' "$*"; }
 warn()  { printf '\e[33m[WARN]\e[0m  %s\n' "$*"; }
 fatal() { printf '\e[31m[FAIL]\e[0m  %s\n' "$*"; exit 1; }
 
-# Load environment overrides if a .env file is present
-if [[ -f .env ]]; then
-  info "Loading variables from .env"
-  set -a
-  # shellcheck disable=SC1091
-  source .env
-  set +a
-fi
 
 ###############################################################################
 # 0. Refresh APT cache & install baseline tools
@@ -137,7 +129,6 @@ info "Waiting for Portainer API…"
 until curl -skf "$PORTAINER_URL/api/status" >/dev/null; do sleep 2; done
 info "Portainer is ready ✔"
 
-
 ###############################################################################
 # 7. Deploy compose stacks through Portainer API
 ###############################################################################
@@ -175,5 +166,4 @@ cat <<'EOM'
 Remember:   usermod --append --groups docker <your_user>
 to grant additional users Docker access.
 EOM
-
 


### PR DESCRIPTION
## Summary
- stop reading `.env` in bootstrap script
- update README instructions
- drop `.env.sample`

## Testing
- `bash -n bootstrap-docker.sh`


------
https://chatgpt.com/codex/tasks/task_e_687e8ed7c720832cb2967068964c9cc8